### PR TITLE
Fix medium screen scaling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
 import ErrorBoundary from "./components/ErrorBoundary/ErrorBoundary";
+import { useResponsiveScale } from "./breakpoints";
 import { AboutUsDesktop } from "./screens/AboutUsDesktop";
 import { CompaniesSolutions } from "./screens/CompaniesSolutions";
 import { ContactUsDesktop } from "./screens/ContactUsDesktop";
@@ -94,9 +95,23 @@ const router = createBrowserRouter([
 ]);
 
 export const App = () => {
+  const scale = useResponsiveScale();
+
+  const wrapperStyle =
+    scale === 1
+      ? { width: "100%", overflowX: "hidden" }
+      : {
+          width: "1440px",
+          transform: `scale(${scale})`,
+          transformOrigin: "top left",
+          overflowX: "hidden",
+        };
+
   return (
     <ErrorBoundary>
-      <RouterProvider router={router} />
+      <div style={wrapperStyle}>
+        <RouterProvider router={router} />
+      </div>
     </ErrorBoundary>
   );
 };

--- a/styleguide.css
+++ b/styleguide.css
@@ -737,15 +737,6 @@ html {
     height: auto !important;
   }
 
-  /* Add slight padding to prevent edge cutoff */
-  .home-mobile,
-  .about-us-desktop,
-  .contact-us-desktop,
-  .showcase-desktop,
-  .companies-solutions {
-    padding-left: 10px !important;
-    padding-right: 10px !important;
-  }
 }
 
 /* Desktop centering and layout fixes */


### PR DESCRIPTION
## Summary
- scale UI down for medium screens using useResponsiveScale
- remove extra padding that caused overflow on medium widths

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68478c5712588323a8cdc4f926ab0da8