### PR TITLE
Update homepage video source

### DIFF
--- a/src/screens/HomeMobile/HomeMobile.jsx
+++ b/src/screens/HomeMobile/HomeMobile.jsx
@@ -282,7 +282,7 @@ export const HomeMobile = () => {
               loop
               muted
               playsInline
-              src="https://cdn.animaapp.com/projects/682f5a093c77459e8b8a213f/files/video_ready_neon_motherboard.mp4"
+              src="/static/img/Video_Ready_Neon_Motherboard.mp4"
               style={{
                 boxShadow: !isMobile ? "12px 20px 4px #eee7f5" : undefined,
                 height: isMobile ? "188.44px" : !isMobile ? "720px" : undefined,


### PR DESCRIPTION
Replaced the Anima video link with a local MP4 file (/static/img/Video_Ready_Neon_Motherboard.mp4) in the homepage component (src/screens/HomeMobile/HomeMobile.jsx).

This change ensures the video is served from the project's static assets.